### PR TITLE
Render exceptions into HTTP response in JSON format

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,7 +2,13 @@
 
 namespace App\Exceptions;
 
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\ValidationException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -46,5 +52,43 @@ class Handler extends ExceptionHandler
         $this->reportable(function (Throwable $e) {
             //
         });
+    }
+
+    /**
+     * Render an exception into an HTTP response.
+     *
+     * @param  Request  $request
+     * @param  \Throwable  $e
+     * @return Response|JsonResponse
+     *
+     * @throws \Exception
+     */
+    public function render($request, \Throwable $e)
+    {
+      $responseBody = [
+        'message' => $e->getMessage()
+      ];
+
+      $code = $e->getCode();
+
+      if ($e instanceof AuthorizationException) {
+        $code = Response::HTTP_UNAUTHORIZED;
+      }
+
+      if ($e instanceof ValidationException) {
+        $code = Response::HTTP_UNPROCESSABLE_ENTITY;
+        $responseBody = array_merge($responseBody, ['errors' => $e->errors()]);
+      }
+
+      if ($e instanceof ModelNotFoundException) {
+        $code = Response::HTTP_NOT_FOUND;
+      }
+
+      if ($code < 100 || $code > 599) {
+        return parent::render($request, $e);
+      }
+
+      $responseBody = array_merge($responseBody, ['code' => $code]);
+      return response()->json($responseBody, $code);
     }
 }

--- a/app/Http/Controllers/Api/Auth/AuthController.php
+++ b/app/Http/Controllers/Api/Auth/AuthController.php
@@ -8,42 +8,25 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
 use App\Http\Resources\UserResource;
 use App\Models\User;
-use App\Repositories\UserRepository;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 
 class AuthController extends Controller
 {
-    /** @var UserRepository  */
-    private UserRepository $repository;
-
     /**
-     * @param UserRepository $repository
+     * @throws \Throwable
      */
-    public function __construct(UserRepository $repository)
-    {
-      $this->repository = $repository;
-    }
-
     public function authenticate(LoginRequest $request): JsonResponse
     {
-      try {
-        $credentials = $request->only(['email', 'password']);
+      $credentials = $request->only(['email', 'password']);
 
-        if (!auth()->attempt($credentials)) {
-          return response()->json(['message' => 'unauthorized', 'code' => 401], Response::HTTP_UNAUTHORIZED);
-        }
+      throw_if(!auth()->attempt($credentials), new AuthorizationException('Unauthorized'));
 
-        /** @var User $user */
-        $user = auth()->user();
-        $token = $user->createToken('API TOKEN')->plainTextToken;
+      /** @var User $user */
+      $user = auth()->user();
+      $token = $user->createToken('API TOKEN')->plainTextToken;
 
-        return response()->json((new UserResource($user))->withToken($token), Response::HTTP_CREATED);
-      } catch (\Exception $exception) {
-        $message = $exception->getMessage();
-        $code = Response::HTTP_INTERNAL_SERVER_ERROR;
-
-        return response()->json(['message' => $message, 'code' => $code], $code);
-      }
+      return response()->json((new UserResource($user))->withToken($token), Response::HTTP_CREATED);
     }
 }

--- a/app/Http/Controllers/Api/User/UserController.php
+++ b/app/Http/Controllers/Api/User/UserController.php
@@ -6,10 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\User\UserRegisterRequest;
 use App\Http\Resources\UserResource;
 use App\Repositories\UserRepository;
-use Couchbase\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
-use Throwable;
 
 class UserController extends Controller
 {
@@ -30,15 +28,8 @@ class UserController extends Controller
      */
     public function create(UserRegisterRequest $request): JsonResponse
     {
-      try {
-        $user = $this->repository->store($request->all());
+      $user = $this->repository->store($request->all());
 
-        return response()->json(new UserResource($user),  Response::HTTP_CREATED);
-      } catch (\Exception $exception) {
-        $message = $exception->getMessage();
-        $code = Response::HTTP_BAD_REQUEST;
-
-        return response()->json(['message' => $message, 'code' => $code], $code);
-      }
+      return response()->json(new UserResource($user),  Response::HTTP_CREATED);
     }
 }


### PR DESCRIPTION
Instead of catching exceptions in methods, ExceptionHandler will render them into custom HTTP response in JSON format.